### PR TITLE
Add GCP Terraform base

### DIFF
--- a/infra/gcp/.terraform.lock.hcl
+++ b/infra/gcp/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "5.45.2"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:k8taQAdfHrv2F/AiGV5BZBZfI+1uaq8g6O8dWzjx42c=",
+    "zh:0d09c8f20b556305192cdbe0efa6d333ceebba963a8ba91f9f1714b5a20c4b7a",
+    "zh:117143fc91be407874568df416b938a6896f94cb873f26bba279cedab646a804",
+    "zh:16ccf77d18dd2c5ef9c0625f9cf546ebdf3213c0a452f432204c69feed55081e",
+    "zh:3e555cf22a570a4bd247964671f421ed7517970cd9765ceb46f335edc2c6f392",
+    "zh:688bd5b05a75124da7ae6e885b2b92bd29f4261808b2b78bd5f51f525c1052ca",
+    "zh:6db3ef37a05010d82900bfffb3261c59a0c247e0692049cb3eb8c2ef16c9d7bf",
+    "zh:70316fde75f6a15d72749f66d994ccbdde5f5ed4311b6d06b99850f698c9bbf9",
+    "zh:84b8e583771a4f2bd514e519d98ed7fd28dce5efe0634e973170e1cfb5556fb4",
+    "zh:9d4b8ef0a9b6677935c604d94495042e68ff5489932cfd1ec41052e094a279d3",
+    "zh:a2089dd9bd825c107b148dd12d6b286f71aa37dfd4ca9c35157f2dcba7bc19d8",
+    "zh:f03d795c0fd9721e59839255ee7ba7414173017dc530b4ce566daf3802a0d6dd",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/infra/gcp/backend.tf
+++ b/infra/gcp/backend.tf
@@ -1,0 +1,6 @@
+terraform {
+  backend "gcs" {
+    bucket = "ns-gcs-sigma-outcome"
+    prefix = "tfstate/novascope"
+  }
+}

--- a/infra/gcp/firestore.indexes.json
+++ b/infra/gcp/firestore.indexes.json
@@ -1,0 +1,4 @@
+{
+  "indexes": [],
+  "fieldOverrides": []
+}

--- a/infra/gcp/firestore.rules
+++ b/infra/gcp/firestore.rules
@@ -1,0 +1,8 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}

--- a/infra/gcp/gcs.tf
+++ b/infra/gcp/gcs.tf
@@ -1,0 +1,5 @@
+resource "google_storage_bucket" "project_bucket" {
+  name                        = "ns-gcs-sigma-outcome"
+  location                    = var.region
+  uniform_bucket_level_access = true
+}

--- a/infra/gcp/iam.tf
+++ b/infra/gcp/iam.tf
@@ -1,0 +1,16 @@
+resource "google_service_account" "functions" {
+  account_id   = var.functions_sa_name
+  display_name = "NovaScope Functions SA"
+}
+
+resource "google_project_iam_member" "functions_secret_access" {
+  project = var.project_id
+  role    = "roles/secretmanager.secretAccessor"
+  member  = "serviceAccount:${google_service_account.functions.email}"
+}
+
+resource "google_project_iam_member" "functions_firestore_access" {
+  project = var.project_id
+  role    = "roles/datastore.user"
+  member  = "serviceAccount:${google_service_account.functions.email}"
+}

--- a/infra/gcp/main.tf
+++ b/infra/gcp/main.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}

--- a/infra/gcp/monitoring.tf
+++ b/infra/gcp/monitoring.tf
@@ -1,0 +1,1 @@
+# Placeholder for future monitoring resources such as alert policies

--- a/infra/gcp/outputs.tf
+++ b/infra/gcp/outputs.tf
@@ -1,0 +1,3 @@
+output "functions_service_account" {
+  value = google_service_account.functions.email
+}

--- a/infra/gcp/pubsub.tf
+++ b/infra/gcp/pubsub.tf
@@ -1,0 +1,3 @@
+resource "google_pubsub_topic" "daily_fetch_topic" {
+  name = "ns-ps-daily-nasa-fetch"
+}

--- a/infra/gcp/scheduler.tf
+++ b/infra/gcp/scheduler.tf
@@ -1,0 +1,10 @@
+resource "google_cloud_scheduler_job" "daily_fetch_job" {
+  name      = "ns-sched-daily-fetch"
+  schedule  = "0 5 * * *"
+  time_zone = "UTC"
+
+  pubsub_target {
+    topic_name = google_pubsub_topic.daily_fetch_topic.id
+    data       = base64encode("{}")
+  }
+}

--- a/infra/gcp/secrets.tf
+++ b/infra/gcp/secrets.tf
@@ -1,0 +1,27 @@
+resource "google_secret_manager_secret" "nasa_api_key" {
+  secret_id = "ns-sm-nasa-api-key"
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret" "r2_access_key_id" {
+  secret_id = "ns-sm-r2-access-key-id"
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret" "r2_secret_access_key" {
+  secret_id = "ns-sm-r2-secret-access-key"
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret" "cf_worker_shared_secret" {
+  secret_id = "ns-sm-shared-auth-token"
+  replication {
+    auto {}
+  }
+}

--- a/infra/gcp/variables.tf
+++ b/infra/gcp/variables.tf
@@ -1,0 +1,16 @@
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region for resources"
+  type        = string
+  default     = "us-central1"
+}
+
+variable "functions_sa_name" {
+  description = "Service account name for Cloud Functions"
+  type        = string
+  default     = "sa-ns-functions"
+}


### PR DESCRIPTION
## Summary
- add Terraform setup for GCP
- define secrets, service account, IAM roles, bucket, pubsub and scheduler
- include backend config and lock file

## Testing
- `terraform fmt -recursive`
- `terraform init -backend=false`
- `terraform validate`


------
https://chatgpt.com/codex/tasks/task_e_683fa2699890832d8284d9c7898f0813