### PR TITLE
Fix incomplete Terraform configs for GCP

### DIFF
--- a/infra/gcp/.terraform.lock.hcl
+++ b/infra/gcp/.terraform.lock.hcl
@@ -1,4 +1,7 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/google" {
   version     = "5.45.2"
   constraints = "~> 5.0"
   hashes = [
@@ -14,4 +17,6 @@
     "zh:9d4b8ef0a9b6677935c604d94495042e68ff5489932cfd1ec41052e094a279d3",
     "zh:a2089dd9bd825c107b148dd12d6b286f71aa37dfd4ca9c35157f2dcba7bc19d8",
     "zh:f03d795c0fd9721e59839255ee7ba7414173017dc530b4ce566daf3802a0d6dd",
-
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/infra/gcp/gcs.tf
+++ b/infra/gcp/gcs.tf
@@ -3,3 +3,4 @@ resource "google_storage_bucket" "project_bucket" {
   name                        = "ns-gcs-sigma-outcome"
   location                    = var.region
   uniform_bucket_level_access = true
+}

--- a/infra/gcp/iam.tf
+++ b/infra/gcp/iam.tf
@@ -1,4 +1,3 @@
-
 resource "google_service_account" "functions" {
   account_id   = var.functions_sa_name
   display_name = "NovaScope Functions SA"
@@ -14,4 +13,4 @@ resource "google_project_iam_member" "functions_firestore_access" {
   project = var.project_id
   role    = "roles/datastore.user"
   member  = "serviceAccount:${google_service_account.functions.email}"
-
+}

--- a/infra/gcp/main.tf
+++ b/infra/gcp/main.tf
@@ -13,3 +13,4 @@ provider "google" {
   project                     = var.project_id
   region                      = var.region
   impersonate_service_account = var.deployer_sa_email
+}

--- a/infra/gcp/pubsub.tf
+++ b/infra/gcp/pubsub.tf
@@ -1,2 +1,3 @@
 resource "google_pubsub_topic" "daily_fetch_topic" {
   name = "ns-ps-daily-nasa-fetch"
+}

--- a/infra/gcp/scheduler.tf
+++ b/infra/gcp/scheduler.tf
@@ -1,4 +1,10 @@
-
+resource "google_cloud_scheduler_job" "daily_fetch_job" {
   name      = "ns-sched-daily-fetch"
   schedule  = "0 5 * * *"
   time_zone = "Asia/Hong_Kong"
+
+  pubsub_target {
+    topic_name = google_pubsub_topic.daily_fetch_topic.id
+    data       = base64encode("{}")
+  }
+}

--- a/infra/gcp/secrets.tf
+++ b/infra/gcp/secrets.tf
@@ -1,5 +1,4 @@
-
-
+resource "google_secret_manager_secret" "nasa_api_key" {
   secret_id = "ns-sm-nasa-api-key"
   replication {
     auto {}
@@ -25,4 +24,4 @@ resource "google_secret_manager_secret" "cf_worker_shared_secret" {
   replication {
     auto {}
   }
-
+}


### PR DESCRIPTION
## Summary
- fix broken provider block in GCP `main.tf`
- close resource blocks in GCS bucket and Pub/Sub topic
- rewrite scheduler job resource
- recreate IAM and Secret Manager resources
- regenerate Terraform lock file

## Testing
- `terraform init -backend=false`
- `terraform validate`

------
https://chatgpt.com/codex/tasks/task_e_683fcd4e4f64832da473a3303ca51e4f